### PR TITLE
Add OpenPolyline to fix Polyline closed shape issue

### DIFF
--- a/examples/src/main/java/dev/equo/draw2d/MultiplePolylines.java
+++ b/examples/src/main/java/dev/equo/draw2d/MultiplePolylines.java
@@ -1,0 +1,75 @@
+package dev.equo.draw2d;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.FigureCanvas;
+import org.eclipse.draw2d.Polyline;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.swt.graphics.OpenPolyline;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+public class MultiplePolylines {
+
+    public static void main(String[] args) {
+        Display display = new Display();
+        Shell shell = new Shell(display);
+        shell.setSize(600, 400);
+        shell.setText("Draw2D Complex Polyline Example");
+
+        FigureCanvas canvas = new FigureCanvas(shell);
+        canvas.setBounds(0, 0, 600, 400);
+
+        Figure root = new Figure();
+
+        // ---------- Figura 1: Triángulo abierto ----------
+        Polyline triangle = new OpenPolyline();
+        triangle.addPoint(new Point(50, 50));
+        triangle.addPoint(new Point(150, 50));
+        triangle.addPoint(new Point(100, 150));
+        triangle.setLineWidth(2);
+        triangle.setForegroundColor(ColorConstants.blue);
+        root.add(triangle);
+
+        // ---------- Figura 2: Zigzag ----------
+        Polyline zigzag = new OpenPolyline();
+        zigzag.addPoint(new Point(200, 50));
+        zigzag.addPoint(new Point(220, 80));
+        zigzag.addPoint(new Point(240, 50));
+        zigzag.addPoint(new Point(260, 80));
+        zigzag.addPoint(new Point(280, 50));
+        zigzag.setLineWidth(3);
+        zigzag.setForegroundColor(ColorConstants.red);
+        root.add(zigzag);
+
+        // ---------- Figura 3: Polilínea más compleja ----------
+        Polyline complex = new OpenPolyline();
+        complex.addPoint(new Point(50, 200));
+        complex.addPoint(new Point(100, 220));
+        complex.addPoint(new Point(150, 210));
+        complex.addPoint(new Point(180, 250));
+        complex.addPoint(new Point(120, 280));
+        complex.addPoint(new Point(60, 260));
+        complex.setLineWidth(2);
+        complex.setForegroundColor(ColorConstants.green);
+        root.add(complex);
+
+        // ---------- Figura 4: Línea abierta simple ----------
+        Polyline simpleLine = new OpenPolyline();
+        simpleLine.addPoint(new Point(300, 200));
+        simpleLine.addPoint(new Point(400, 300));
+        simpleLine.setLineWidth(4);
+        simpleLine.setForegroundColor(ColorConstants.darkGray);
+        root.add(simpleLine);
+
+        canvas.setContents(root);
+
+        shell.open();
+        while (!shell.isDisposed()) {
+            if (!display.readAndDispatch())
+                display.sleep();
+        }
+        display.dispose();
+    }
+}
+

--- a/examples/src/main/java/dev/equo/draw2d/ThreeSidesFigureExample.java
+++ b/examples/src/main/java/dev/equo/draw2d/ThreeSidesFigureExample.java
@@ -1,0 +1,47 @@
+package dev.equo.draw2d;
+
+import org.eclipse.draw2d.Figure;
+import org.eclipse.draw2d.FigureCanvas;
+import org.eclipse.draw2d.Polyline;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.swt.graphics.OpenPolyline;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+public class ThreeSidesFigureExample {
+
+    public static void main(String[] args) {
+        Display display = new Display();
+        Shell shell = new Shell(display);
+        shell.setSize(400, 300);
+        shell.setText("Draw2D Three Sides Square Example");
+
+        FigureCanvas canvas = new FigureCanvas(shell);
+        canvas.setBounds(0, 0, 400, 300);
+
+        Figure root = new Figure();
+
+        // Figura de solo 3 lados
+        Polyline triangleSquare = new OpenPolyline();
+        triangleSquare.addPoint(new Point(50, 50));
+        triangleSquare.addPoint(new Point(150, 50));
+        triangleSquare.addPoint(new Point(150, 150));
+        triangleSquare.addPoint(new Point(100, 200));
+        // NOTA: no cierra la figura (no vuelve al punto inicial)
+
+        triangleSquare.setLineWidth(2);
+        triangleSquare.setForegroundColor(ColorConstants.blue);
+
+        root.add(triangleSquare);
+
+        canvas.setContents(root);
+
+        shell.open();
+        while (!shell.isDisposed()) {
+            if (!display.readAndDispatch())
+                display.sleep();
+        }
+        display.dispose();
+    }
+}

--- a/swt_native/build.gradle.kts
+++ b/swt_native/build.gradle.kts
@@ -7,6 +7,19 @@ plugins {
 
 repositories {
     mavenCentral()
+    ivy {
+        url = uri("https://download.eclipse.org/releases/2024-12/202412041000/plugins/")
+        name = "Eclipse 2024-12 Plugins"
+        patternLayout {
+            artifact("[organisation].[artifact]_[revision].[ext]")
+        }
+        metadataSources {
+            artifact()
+        }
+        content {
+            includeModule("org.eclipse", "draw2d")
+        }
+    }
 }
 
 val arch = System.getProperty("os.arch")
@@ -27,6 +40,7 @@ val currentOs = when {
 val currentPlatform = "$currentOs-${if (arch.contains("aarch64") || arch.contains("arm")) "aarch64" else "x86_64"}"
 
 val swtVersion = "3.128.0.v20241113-2009"
+val draw2dVersion = "3.18.0.202411181923"
 
 val swtVersionConfig by configurations.creating {
     isCanBeConsumed = false
@@ -44,6 +58,8 @@ dependencies {
     implementation(libs.equo.comm.ws) {
         exclude(group = "dev.equo", module = "com.equo.comm.common")
     }
+
+    implementation("org.eclipse:draw2d:${draw2dVersion}")
 
     implementation(libs.auto.value.annotations)
     annotationProcessor(libs.auto.value.annotations)

--- a/swt_native/src/main/java/org/eclipse/swt/graphics/OpenPolyline.java
+++ b/swt_native/src/main/java/org/eclipse/swt/graphics/OpenPolyline.java
@@ -1,0 +1,23 @@
+package org.eclipse.swt.graphics;
+import org.eclipse.draw2d.Polyline;
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.draw2d.Graphics;
+import org.eclipse.draw2d.geometry.Point;
+
+public class OpenPolyline extends Polyline {
+
+    @Override
+    protected void outlineShape(Graphics g) {
+        PointList pts = getPoints();
+
+        if (pts == null || pts.size() < 2) {
+            return;
+        }
+
+        for (int i = 0; i < pts.size() - 1; i++) {
+            Point p1 = pts.getPoint(i);
+            Point p2 = pts.getPoint(i + 1);
+            g.drawLine(p1.x, p1.y, p2.x, p2.y);
+        }
+    }
+}

--- a/swt_native/src/test/java/org/eclipse/swt/graphics/OpenPolylineTest.java
+++ b/swt_native/src/test/java/org/eclipse/swt/graphics/OpenPolylineTest.java
@@ -1,0 +1,53 @@
+package org.eclipse.swt.graphics;
+
+import org.eclipse.draw2d.geometry.PointList;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.Graphics;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class OpenPolylineTest {
+
+    @Test
+    void should_not_draw_when_points_are_null() {
+        Graphics g = Mockito.mock(Graphics.class);
+        OpenPolyline polyline = new OpenPolyline();
+
+        polyline.outlineShape(g);
+
+        Mockito.verify(g, Mockito.never()).drawLine(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt());
+    }
+
+    @Test
+    void should_not_draw_when_less_than_two_points() {
+        Graphics g = Mockito.mock(Graphics.class);
+        OpenPolyline polyline = new OpenPolyline();
+
+        PointList points = new PointList();
+        points.addPoint(new Point(10, 10));
+        polyline.setPoints(points);
+
+        polyline.outlineShape(g);
+
+        Mockito.verify(g, Mockito.never()).drawLine(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt());
+    }
+
+    @Test
+    void should_draw_lines_between_consecutive_points() {
+        Graphics g = Mockito.mock(Graphics.class);
+        OpenPolyline polyline = new OpenPolyline();
+
+        PointList points = new PointList();
+        points.addPoint(new Point(0, 0));
+        points.addPoint(new Point(10, 10));
+        points.addPoint(new Point(20, 5));
+        polyline.setPoints(points);
+
+        polyline.outlineShape(g);
+
+        Mockito.verify(g).drawLine(0, 0, 10, 10);
+        Mockito.verify(g).drawLine(10, 10, 20, 5);
+
+        Mockito.verifyNoMoreInteractions(g);
+    }
+}


### PR DESCRIPTION
Se corrigió el comportamiento de Polyline, que cerraba automáticamente las figuras al ejecutar g.drawPolyline(this.points) dentro de outlineShape(Graphics g).
Se creó una nueva clase OpenPolyline que redefine outlineShape(Graphics g) para dibujar únicamente líneas entre puntos consecutivos mediante g.drawLine(p1.x, p1.y, p2.x, p2.y), evitando el cierre automático.