### PR TITLE
#43 - Remove fix references from web display and image regression tests

### DIFF
--- a/swt_native/src/main/java/org/eclipse/swt/graphics/GraphicsUtils.java
+++ b/swt_native/src/main/java/org/eclipse/swt/graphics/GraphicsUtils.java
@@ -173,9 +173,7 @@ public class GraphicsUtils {
      *     or null if path is null
      */
     static String getFilename(String path) {
-        if (path == null) {
-            return null;
-        }
+        if (path == null) return null;
         String fileName = new java.io.File(path).getName();
         int dotIndex = fileName.lastIndexOf('.');
         return (dotIndex > 0) ? fileName.substring(0, dotIndex) : fileName;

--- a/swt_native/src/test/java/dev/equo/swt/WebDisplayImageFlutterTest.java
+++ b/swt_native/src/test/java/dev/equo/swt/WebDisplayImageFlutterTest.java
@@ -14,12 +14,13 @@ import org.junit.jupiter.api.*;
 import static org.assertj.core.api.Assertions.*;
 
 /**
- * Regression tests for the three web-mode fixes described in CHANGES.md.
+ * Regression tests for web-mode behavior: monitor bounds consistency,
+ * image provider null-path handling, and image provider exception recovery.
  * Compiled against the web backend (webMain) via the webTest source set.
  * Run with: ./gradlew :swt_native:webTest
  */
 @Tag("flutter-it")
-class WebFixesFlutterTest {
+class WebDisplayImageFlutterTest {
 
     private static FlutterHarness flutter;
     private static Display display;
@@ -39,9 +40,6 @@ class WebFixesFlutterTest {
         if (flutter != null) flutter.teardown();
     }
 
-    // Fix 1: DartDisplay.getPrimaryMonitor() was returning a Monitor with zeroed
-    // bounds because it omitted the monitor.setBounds(bounds) / setClientArea(bounds)
-    // calls that getMonitors() already had. After the fix both must agree.
     @Test
     void getPrimaryMonitor_bounds_consistent_with_getMonitors() {
         Monitor primary = display.getPrimaryMonitor();
@@ -52,10 +50,6 @@ class WebFixesFlutterTest {
         assertThat(primary.getClientArea()).isEqualTo(primaryBounds);
     }
 
-    // Fix 2 (web): When ImageFileNameProvider.getImagePath(100) returns null (as it
-    // does for JFace bundle-URL resources in web mode), DartImage must throw a
-    // SWTException so JFace can catch it and fall back to InputStream loading —
-    // not a NullPointerException which JFace does not catch.
     @Test
     void imageFileNameProvider_null_path_throws_SWTException_not_NPE() {
         ImageFileNameProvider nullPathProvider = zoom -> null;
@@ -64,10 +58,6 @@ class WebFixesFlutterTest {
                 .isNotInstanceOf(NullPointerException.class);
     }
 
-    // Fix 3: When ImageDataProvider.getImageData(100) throws SWTException (e.g.
-    // "No SVG rasterizer found"), DartImage must absorb the exception and use a
-    // 1x1 placeholder instead of propagating it — which would crash the caller
-    // (ProgressMonitorPart) since it does not wrap new Image() in a try-catch.
     @Test
     void imageDataProvider_swt_exception_falls_back_to_placeholder() {
         ImageDataProvider throwingProvider = zoom -> {

--- a/swt_native/src/test/java/dev/equo/swt/WebFixesFlutterTest.java
+++ b/swt_native/src/test/java/dev/equo/swt/WebFixesFlutterTest.java
@@ -1,0 +1,79 @@
+package dev.equo.swt;
+
+import dev.equo.swt.harness.FlutterHarness;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.ImageDataProvider;
+import org.eclipse.swt.graphics.ImageFileNameProvider;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Monitor;
+import org.junit.jupiter.api.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Regression tests for the three web-mode fixes described in CHANGES.md.
+ * Compiled against the web backend (webMain) via the webTest source set.
+ * Run with: ./gradlew :swt_native:webTest
+ */
+@Tag("flutter-it")
+class WebFixesFlutterTest {
+
+    private static FlutterHarness flutter;
+    private static Display display;
+
+    @BeforeAll
+    static void setup() {
+        flutter = new FlutterHarness();
+        // Injects the harness as the global bridge before Display is created, which
+        // causes SwtFlutterBridgeWeb.initForDisplay to skip starting its own server.
+        flutter.init();
+        display = new Display();
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (display != null && !display.isDisposed()) display.dispose();
+        if (flutter != null) flutter.teardown();
+    }
+
+    // Fix 1: DartDisplay.getPrimaryMonitor() was returning a Monitor with zeroed
+    // bounds because it omitted the monitor.setBounds(bounds) / setClientArea(bounds)
+    // calls that getMonitors() already had. After the fix both must agree.
+    @Test
+    void getPrimaryMonitor_bounds_consistent_with_getMonitors() {
+        Monitor primary = display.getPrimaryMonitor();
+        Rectangle primaryBounds = primary.getBounds();
+        Rectangle firstMonitorBounds = display.getMonitors()[0].getBounds();
+
+        assertThat(primaryBounds).isEqualTo(firstMonitorBounds);
+        assertThat(primary.getClientArea()).isEqualTo(primaryBounds);
+    }
+
+    // Fix 2 (web): When ImageFileNameProvider.getImagePath(100) returns null (as it
+    // does for JFace bundle-URL resources in web mode), DartImage must throw a
+    // SWTException so JFace can catch it and fall back to InputStream loading —
+    // not a NullPointerException which JFace does not catch.
+    @Test
+    void imageFileNameProvider_null_path_throws_SWTException_not_NPE() {
+        ImageFileNameProvider nullPathProvider = zoom -> null;
+        assertThatThrownBy(() -> new Image(display, nullPathProvider))
+                .isInstanceOf(SWTException.class)
+                .isNotInstanceOf(NullPointerException.class);
+    }
+
+    // Fix 3: When ImageDataProvider.getImageData(100) throws SWTException (e.g.
+    // "No SVG rasterizer found"), DartImage must absorb the exception and use a
+    // 1x1 placeholder instead of propagating it — which would crash the caller
+    // (ProgressMonitorPart) since it does not wrap new Image() in a try-catch.
+    @Test
+    void imageDataProvider_swt_exception_falls_back_to_placeholder() {
+        ImageDataProvider throwingProvider = zoom -> {
+            throw new SWTException(SWT.ERROR_UNSUPPORTED_FORMAT);
+        };
+        Image image = new Image(display, throwingProvider);
+        image.dispose();
+    }
+}

--- a/swt_native/src/test/java/org/eclipse/swt/graphics/GraphicsUtilsTest.java
+++ b/swt_native/src/test/java/org/eclipse/swt/graphics/GraphicsUtilsTest.java
@@ -44,6 +44,11 @@ public class GraphicsUtilsTest extends SerializeTestBase {
     }
 
     @Test
+    public void should_return_null_when_path_is_null() {
+        assertThat(GraphicsUtils.getFilename(null)).isNull();
+    }
+
+    @Test
     public void should_copy_fontdata() {
         // Create a FontData
         FontData original = new FontData("Arial", 12, SWT.BOLD);

--- a/swt_native/src/webMain/java/org/eclipse/swt/graphics/DartImage.java
+++ b/swt_native/src/webMain/java/org/eclipse/swt/graphics/DartImage.java
@@ -566,8 +566,11 @@ public final class DartImage extends DartResource implements Drawable, IImage {
         if (imageFileNameProvider == null)
             SWT.error(SWT.ERROR_NULL_ARGUMENT);
         try {
-            this.filename = GraphicsUtils.getFilename(imageFileNameProvider.getImagePath(100));
-            imageData = new ImageData(imageFileNameProvider.getImagePath(100));
+            String path100 = imageFileNameProvider.getImagePath(100);
+            if (path100 == null)
+                SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+            this.filename = GraphicsUtils.getFilename(path100);
+            imageData = new ImageData(path100);
             initUsingFileNameProvider(imageFileNameProvider);
             init(imageData, 100);
             init();

--- a/swt_native/src/webMain/java/org/eclipse/swt/graphics/DartImage.java
+++ b/swt_native/src/webMain/java/org/eclipse/swt/graphics/DartImage.java
@@ -933,12 +933,22 @@ public final class DartImage extends DartResource implements Drawable, IImage {
 
     private void initUsingImageDataProvider(ImageDataProvider imageDataProvider) {
         this.imageDataProvider = imageDataProvider;
-        ImageData imageData = imageDataProvider.getImageData(100);
+        ImageData imageData;
+        try {
+            imageData = imageDataProvider.getImageData(100);
+        } catch (SWTException e) {
+            imageData = null;
+        }
         if (imageData == null) {
-            SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+            imageData = new ImageData(1, 1, 32, new PaletteData(0xFF0000, 0xFF00, 0xFF));
         }
         init(imageData, 100);
-        ImageData imageData2x = imageDataProvider.getImageData(200);
+        ImageData imageData2x;
+        try {
+            imageData2x = imageDataProvider.getImageData(200);
+        } catch (SWTException e) {
+            imageData2x = null;
+        }
         if (imageData2x != null) {
             alphaInfo_200 = new AlphaInfo();
         }

--- a/swt_native/src/webMain/java/org/eclipse/swt/widgets/DartDisplay.java
+++ b/swt_native/src/webMain/java/org/eclipse/swt/widgets/DartDisplay.java
@@ -1386,6 +1386,8 @@ public class DartDisplay extends DartDevice implements Executor, IDisplay {
     public Monitor getPrimaryMonitor() {
         checkDevice();
         Monitor monitor = new Monitor();
+        monitor.setBounds(bounds);
+        monitor.setClientArea(bounds);
         return monitor;
     }
 


### PR DESCRIPTION
Three independent issues were preventing WizardDialog from opening in web mode:

- Mispositioned dialog: DartDisplay.getPrimaryMonitor() returned a Monitor with uninitialized bounds, placing the dialog at negative coordinates. Aligned it with the existing behavior in getMonitors().
- NullPointerException on image load: In web mode, getImagePath(100) returns null for bundle resources. The DartImage constructor now throws SWTException in that case, letting JFace fall back to its InputStream path instead of crashing.
- Unhandled SVG load failure: With no SVGRasterizer on the classpath, loading SVG icons via imageDataProvider was throwing an uncaught SWTException. Now falls back to a 1×1 placeholder so the wizard opens, even if JFace icons don't render.